### PR TITLE
add: generate different css files with fontGear

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,23 @@ After processing:
 - `remPrecision`: number, default `6`
 - `addPrefixToSelector`: function
 - `dprList`: array, default `[3, 2, 1]`
+- `fontGear`: array, default `[-1, 0, 1, 2, 3, 4]`
+- `enableFontSetting`: boolean, default `false`
+- `addFontSizeToSelector`: function
+- `outputCSSFile`: function
 
 ## Change Log
+
+* add: generate different css files with fontGear
+* support custom `fontGear`
+* support custom `enableFontSetting`
+* support custom `addFontSizeToSelector`
+* support custom `outputCSSFile`
+
+
+### 0.5.0
+
+* support custom `dprList`
 
 ### 0.4.0
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
       }
       return prefix + ' ' + selector
     }
-    var addFontSizeToSelector = function (originFontSize, gear = 0, baseDpr = 2) {
+    var addFontSizeToSelector = function (originFontSize, gear, baseDpr) {
+      if (!gear) {
+        gear = 0
+      }
       if (!enableFontSetting) {
         return originFontSize
       }
@@ -151,7 +154,6 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
           desktop ? handleDesktop(rule) : handleMobile(rule, gear)
         })
       }
-    } else {
     }
     root.walkRules(function (rule) {
       desktop ? handleDesktop(rule) : handleMobile(rule)

--- a/index.js
+++ b/index.js
@@ -37,11 +37,7 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
       }
       return +originFontSize + gear*baseDpr
     }
-    var outputCSSFile = options.outputCSSFile || function (gear, clonedRoot) {
-      gear !== undefined && fs.writeFileSync(path.join(__dirname, 'test/fontGear/fontGear_' + gear +'.css'), clonedRoot, {
-        encoding: 'utf8'
-      })
-    }
+    var outputCSSFile = options.outputCSSFile || function (gear, clonedRoot) {}
     var dprList = (options.dprList || [3, 2, 1]).sort().reverse()
     fontGear = fontGear.sort().reverse()
     var urlRegExp = new RegExp('url\\([\'"]?\\S+?@(' + dprList.join('|') + ')x\\S+?[\'"]?\\)')

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var postcss = require('postcss')
+var path = require('path')
+var fs = require('fs')
 
 var valueRegExp = /(dpr|rem|url)\((.+?)(px)?\)/
 var dprRegExp = /dpr\((\d+(?:\.\d+)?)px\)/
@@ -15,17 +17,34 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
     var baseDpr = options.baseDpr || 2
     var remUnit = options.remUnit || 75
     var remPrecision = options.remPrecision || 6
+    var enableFontSetting = options.enableFontSetting || false
+    var fontGear = Object.prototype.toString.call(options.fontGear) === '[object Array]' ? options.fontGear : [-1, 0, 1, 2, 3, 4]
     var addPrefixToSelector = options.addPrefixToSelector || function (selector, prefix) {
       if (/^html/.test(selector)) {
         return selector.replace(/^html/, 'html' + prefix)
       }
       return prefix + ' ' + selector
     }
+    var addFontSizeToSelector = function (originFontSize, gear = 0, baseDpr = 2) {
+      if (!enableFontSetting) {
+        return originFontSize
+      }
+      if (options.addFontSizeToSelector) {
+        return options.addFontSizeToSelector(originFontSize, gear, baseDpr)
+      }
+      return +originFontSize + gear*baseDpr
+    }
+    var outputCSSFile = options.outputCSSFile || function (gear, clonedRoot) {
+      gear !== undefined && fs.writeFileSync(path.join(__dirname, 'test/fontGear/fontGear_' + gear +'.css'), clonedRoot, {
+        encoding: 'utf8'
+      })
+    }
     var dprList = (options.dprList || [3, 2, 1]).sort().reverse()
+    fontGear = fontGear.sort().reverse()
     var urlRegExp = new RegExp('url\\([\'"]?\\S+?@(' + dprList.join('|') + ')x\\S+?[\'"]?\\)')
 
     // get calculated value of px or rem
-    function getCalcValue (value, dpr) {
+    function getCalcValue (value, dpr, gear) {
       var valueGlobalRegExp = new RegExp(valueRegExp.source, 'g')
 
       function getValue(val, type) {
@@ -39,7 +58,7 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
           }
         } else if ($1 === 'dpr') {
           if (dpr) {
-            return getValue($2 * dpr / baseDpr, 'px')
+            return getValue(addFontSizeToSelector($2, gear, baseDpr) * dpr / baseDpr, 'px')
           }
         } else if ($1 === 'rem') {
           return getValue($2 / remUnit, 'rem')
@@ -65,11 +84,10 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
       })
     }
 
-    function handleMobile (rule) {
+    function handleMobile (rule, gear) {
       if (rule.selector.indexOf('[data-dpr="') !== -1) {
         return
       }
-
       var newRules = []
       var hasDecls = false
 
@@ -78,7 +96,8 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
           selectors: rule.selectors.map(function (sel) {
             return addPrefixToSelector(sel, '[data-dpr="' + dprList[i] + '"]')
           }),
-          type: rule.type
+          type: rule.type,
+          customGear: gear
         })
         newRules.push(newRule)
       }
@@ -93,7 +112,7 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
               newRules.forEach(function (newRule, index) {
                 var newDecl = postcss.decl({
                   prop: decl.prop,
-                  value: getCalcValue(decl.value, dprList[index])
+                  value: getCalcValue(decl.value, dprList[index % dprList.length], newRule.customGear)
                 })
                 newRule.append(newDecl)
               })
@@ -107,6 +126,7 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
         }
       })
 
+      // insert the updated rules into its parent Node
       if (hasDecls) {
         newRules.forEach(function (newRule) {
           rule.parent.insertAfter(rule, newRule)
@@ -117,8 +137,22 @@ module.exports = postcss.plugin('postcss-flexible', function (options) {
       if (!rule.nodes.length) {
         rule.remove()
       }
+      // output the css file with different fontGear
+      if (hasDecls && outputCSSFile) {
+        outputCSSFile(gear, clonedRoot)
+      }
     }
-
+    if (enableFontSetting) {
+      for (var j = 0; j < fontGear.length; j++) {
+        var gear = fontGear[j]
+        // clone the root element so that the operation blow won't distructe the origin root element
+        var clonedRoot = root.clone()
+        clonedRoot.walkRules(function (rule) {
+          desktop ? handleDesktop(rule) : handleMobile(rule, gear)
+        })
+      }
+    } else {
+    }
     root.walkRules(function (rule) {
       desktop ? handleDesktop(rule) : handleMobile(rule)
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,659 @@
+{
+  "name": "postcss-flexible",
+  "version": "0.4.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "http://registry.npm.sdp.nd/abbrev/download/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.sdp.nd/amdefine/download/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.sdp.nd/ansi-regex/download/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "http://registry.npm.sdp.nd/ansi-styles/download/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "http://registry.npm.sdp.nd/argparse/download/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "http://registry.npm.sdp.nd/async/download/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.sdp.nd/balanced-match/download/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://registry.npm.sdp.nd/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.sdp.nd/browser-stdout/download/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.sdp.nd/chalk/download/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.sdp.nd/supports-color/download/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "http://registry.npm.sdp.nd/commander/download/commander-2.17.1.tgz",
+      "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
+      "dev": true,
+      "optional": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://registry.npm.sdp.nd/concat-map/download/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "http://registry.npm.sdp.nd/debug/download/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "http://registry.npm.sdp.nd/deep-is/download/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "http://registry.npm.sdp.nd/diff/download/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.sdp.nd/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "http://registry.npm.sdp.nd/escodegen/download/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "http://registry.npm.sdp.nd/source-map/download/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "http://registry.npm.sdp.nd/esprima/download/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "http://registry.npm.sdp.nd/estraverse/download/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.sdp.nd/esutils/download/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "http://registry.npm.sdp.nd/fast-levenshtein/download/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.sdp.nd/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "http://registry.npm.sdp.nd/glob/download/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.sdp.nd/graceful-readlink/download/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "http://registry.npm.sdp.nd/growl/download/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.12",
+      "resolved": "http://registry.npm.sdp.nd/handlebars/download/handlebars-4.0.12.tgz",
+      "integrity": "sha1-LBXIqW1G2l4mZwBRi6jLjZGdW8U=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.4.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "http://registry.npm.sdp.nd/async/download/async-2.6.1.tgz",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.sdp.nd/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.sdp.nd/has-ansi/download/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.sdp.nd/has-flag/download/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.sdp.nd/he/download/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.sdp.nd/inflight/download/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.sdp.nd/inherits/download/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.sdp.nd/isexe/download/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "http://registry.npm.sdp.nd/istanbul/download/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.12",
+        "js-yaml": "3.12.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.1",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "js-base64": {
+      "version": "2.4.9",
+      "resolved": "http://registry.npm.sdp.nd/js-base64/download/js-base64-2.4.9.tgz",
+      "integrity": "sha1-dIkR+wT0imDEdxs3XKxFqA3xHAM="
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "http://registry.npm.sdp.nd/js-yaml/download/js-yaml-3.12.0.tgz",
+      "integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "http://registry.npm.sdp.nd/esprima/download/esprima-4.0.1.tgz",
+          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+          "dev": true
+        }
+      }
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "http://registry.npm.sdp.nd/json3/download/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.sdp.nd/levn/download/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "http://registry.npm.sdp.nd/lodash/download/lodash-4.17.11.tgz",
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "http://registry.npm.sdp.nd/lodash._baseassign/download/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.sdp.nd/lodash._basecopy/download/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "http://registry.npm.sdp.nd/lodash._basecreate/download/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "http://registry.npm.sdp.nd/lodash._getnative/download/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "http://registry.npm.sdp.nd/lodash._isiterateecall/download/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "http://registry.npm.sdp.nd/lodash.create/download/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.sdp.nd/lodash.isarguments/download/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "http://registry.npm.sdp.nd/lodash.isarray/download/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "http://registry.npm.sdp.nd/lodash.keys/download/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://registry.npm.sdp.nd/minimatch/download/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "http://registry.npm.sdp.nd/minimist/download/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npm.sdp.nd/mkdirp/download/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npm.sdp.nd/minimist/download/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "http://registry.npm.sdp.nd/mocha/download/mocha-3.5.3.tgz",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "http://registry.npm.sdp.nd/commander/download/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "http://registry.npm.sdp.nd/glob/download/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "http://registry.npm.sdp.nd/supports-color/download/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.sdp.nd/ms/download/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "http://registry.npm.sdp.nd/nopt/download/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.sdp.nd/once/download/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "http://registry.npm.sdp.nd/optimist/download/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "http://registry.npm.sdp.nd/wordwrap/download/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "http://registry.npm.sdp.nd/optionator/download/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.sdp.nd/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "http://registry.npm.sdp.nd/postcss/download/postcss-5.2.18.tgz",
+      "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.4.9",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.sdp.nd/prelude-ls/download/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "http://registry.npm.sdp.nd/resolve/download/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "http://registry.npm.sdp.nd/source-map/download/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.sdp.nd/sprintf-js/download/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.sdp.nd/strip-ansi/download/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "http://registry.npm.sdp.nd/supports-color/download/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "http://registry.npm.sdp.nd/type-check/download/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "http://registry.npm.sdp.nd/uglify-js/download/uglify-js-3.4.9.tgz",
+      "integrity": "sha1-rwLxgMEgfXZDLkc+0koo9KeCuuM=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.sdp.nd/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "http://registry.npm.sdp.nd/which/download/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.sdp.nd/wordwrap/download/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.sdp.nd/wrappy/download/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/test/customFile/fontGear_-1.css
+++ b/test/customFile/fontGear_-1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 15px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 30px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 45px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 9px
+}
+[data-dpr="2"] .selector3 {
+    padding: 18px
+}
+[data-dpr="3"] .selector3 {
+    padding: 27px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 9px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 18px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 27px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 9px
+    }
+    [data-dpr="2"] body {
+        margin: 18px
+    }
+    [data-dpr="3"] body {
+        margin: 27px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 3px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 6px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 9px
+}

--- a/test/customFile/fontGear_0.css
+++ b/test/customFile/fontGear_0.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 16px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 32px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 48px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 10px
+}
+[data-dpr="2"] .selector3 {
+    padding: 20px
+}
+[data-dpr="3"] .selector3 {
+    padding: 30px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 10px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 20px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 30px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 10px
+    }
+    [data-dpr="2"] body {
+        margin: 20px
+    }
+    [data-dpr="3"] body {
+        margin: 30px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 4px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 12px
+}

--- a/test/customFile/fontGear_1.css
+++ b/test/customFile/fontGear_1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 17px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 34px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 51px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 11px
+}
+[data-dpr="2"] .selector3 {
+    padding: 22px
+}
+[data-dpr="3"] .selector3 {
+    padding: 33px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 11px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 22px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 33px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 11px
+    }
+    [data-dpr="2"] body {
+        margin: 22px
+    }
+    [data-dpr="3"] body {
+        margin: 33px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 5px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 10px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 15px
+}

--- a/test/customFile/fontGear_2.css
+++ b/test/customFile/fontGear_2.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 18px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 36px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 54px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 12px
+}
+[data-dpr="2"] .selector3 {
+    padding: 24px
+}
+[data-dpr="3"] .selector3 {
+    padding: 36px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 12px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 24px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 36px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 12px
+    }
+    [data-dpr="2"] body {
+        margin: 24px
+    }
+    [data-dpr="3"] body {
+        margin: 36px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 6px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 12px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 18px
+}

--- a/test/customFile/fontGear_3.css
+++ b/test/customFile/fontGear_3.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 19px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 38px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 57px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 13px
+}
+[data-dpr="2"] .selector3 {
+    padding: 26px
+}
+[data-dpr="3"] .selector3 {
+    padding: 39px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 13px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 26px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 39px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 13px
+    }
+    [data-dpr="2"] body {
+        margin: 26px
+    }
+    [data-dpr="3"] body {
+        margin: 39px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 7px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 14px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 21px
+}

--- a/test/customFile/fontGear_4.css
+++ b/test/customFile/fontGear_4.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 20px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 40px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 60px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 14px
+}
+[data-dpr="2"] .selector3 {
+    padding: 28px
+}
+[data-dpr="3"] .selector3 {
+    padding: 42px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 14px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 28px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 42px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 14px
+    }
+    [data-dpr="2"] body {
+        margin: 28px
+    }
+    [data-dpr="3"] body {
+        margin: 42px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 16px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 24px
+}

--- a/test/flexible.spec.js
+++ b/test/flexible.spec.js
@@ -58,4 +58,70 @@ describe('postcss-flexible', function() {
     assert.equal(outputText.trim(), expectedText.trim())
   })
 
+  it('should output right css text with enableFontSetting', function() {
+    var srcPath = path.join(__dirname, 'source.css')
+    var srcText = fs.readFileSync(srcPath, {
+      encoding: 'utf8'
+    })
+    const fontGear = [-1, 0, 1, 2, 3, 4]
+
+    postcss().use(flexible({ enableFontSetting: true, fontGear: fontGear })).process(srcText).css
+    // console.log(outputText)
+    for (let i = -1, len = fontGear.length - 1; i < len; i++) {
+      var outputText = fs.readFileSync(path.join(__dirname, 'fontGear/fontGear_' + i +'.css'), {
+        encoding: 'utf8'
+      })
+      var expectedText = fs.readFileSync(path.join(__dirname, 'fontGearSource/fontGear_' + i +'.css'), {
+        encoding: 'utf8'
+      })
+     assert.equal(outputText.trim(), expectedText.trim())
+    }
+  })
+  it('should output right css text with enableFontSetting and addFontSizeToSelector', function() {
+    var srcPath = path.join(__dirname, 'source.css')
+    var srcText = fs.readFileSync(srcPath, {
+      encoding: 'utf8'
+    })
+    const fontGear = [-1, 0, 1, 2, 3, 4]
+    const addFontSizeToSelector = function (originFontSize, gear, baseDpr = 2) {
+      return +originFontSize + gear*baseDpr*2
+    }
+    const output = postcss().use(flexible({ enableFontSetting: true, fontGear: fontGear, addFontSizeToSelector: addFontSizeToSelector })).process(srcText).css
+    var expectedText = fs.readFileSync(path.join(__dirname, 'output.css'), {
+      encoding: 'utf8'
+    })
+    assert.equal(output.trim(), expectedText.trim())
+    for (let i = -1, len = fontGear.length - 1; i < len; i++) {
+      var outputText = fs.readFileSync(path.join(__dirname, 'fontGear/fontGear_' + i +'.css'), {
+        encoding: 'utf8'
+      })
+      var expectedText = fs.readFileSync(path.join(__dirname, 'fontGearCustom/fontGear_' + i +'.css'), {
+        encoding: 'utf8'
+      })
+     assert.equal(outputText.trim(), expectedText.trim())
+    }
+  })
+  it('should output right css text with enableFontSetting and custom output', function() {
+    var srcPath = path.join(__dirname, 'source.css')
+    var srcText = fs.readFileSync(srcPath, {
+      encoding: 'utf8'
+    })
+    const fontGear = [-1, 0, 1, 2, 3, 4]
+    var outputCSSFile = function(gear, clonedRoot) {
+      gear !== undefined && fs.writeFileSync(path.join(__dirname, 'customFile/fontGear_' + gear +'.css'), clonedRoot, {
+        encoding: 'utf8'
+      })
+    }
+    postcss().use(flexible({ enableFontSetting: true, fontGear: fontGear, outputCSSFile: outputCSSFile })).process(srcText).css
+    // console.log(outputText)
+    for (let i = -1, len = fontGear.length - 1; i < len; i++) {
+      var outputText = fs.readFileSync(path.join(__dirname, 'customFile/fontGear_' + i +'.css'), {
+        encoding: 'utf8'
+      })
+      var expectedText = fs.readFileSync(path.join(__dirname, 'fontGearSource/fontGear_' + i +'.css'), {
+        encoding: 'utf8'
+      })
+     assert.equal(outputText.trim(), expectedText.trim())
+    }
+  })
 })

--- a/test/flexible.spec.js
+++ b/test/flexible.spec.js
@@ -83,7 +83,10 @@ describe('postcss-flexible', function() {
       encoding: 'utf8'
     })
     const fontGear = [-1, 0, 1, 2, 3, 4]
-    const addFontSizeToSelector = function (originFontSize, gear, baseDpr = 2) {
+    const addFontSizeToSelector = function (originFontSize, gear, baseDpr) {
+      if (!baseDpr) {
+        baseDpr = 2
+      }
       return +originFontSize + gear*baseDpr*2
     }
     const output = postcss().use(flexible({ enableFontSetting: true, fontGear: fontGear, addFontSizeToSelector: addFontSizeToSelector })).process(srcText).css

--- a/test/flexible.spec.js
+++ b/test/flexible.spec.js
@@ -63,9 +63,17 @@ describe('postcss-flexible', function() {
     var srcText = fs.readFileSync(srcPath, {
       encoding: 'utf8'
     })
-    const fontGear = [-1, 0, 1, 2, 3, 4]
-
-    postcss().use(flexible({ enableFontSetting: true, fontGear: fontGear })).process(srcText).css
+    var fontGear = [-1, 0, 1, 2, 3, 4]
+    var outputCSSFile = function(gear, clonedRoot) {
+      gear !== undefined && fs.writeFileSync(path.join(__dirname, 'fontGear/fontGear_' + gear +'.css'), clonedRoot, {
+        encoding: 'utf8'
+      })
+    }
+    postcss().use(flexible({
+      enableFontSetting: true,
+      fontGear: fontGear,
+      outputCSSFile: outputCSSFile
+    })).process(srcText).css
     // console.log(outputText)
     for (let i = -1, len = fontGear.length - 1; i < len; i++) {
       var outputText = fs.readFileSync(path.join(__dirname, 'fontGear/fontGear_' + i +'.css'), {
@@ -82,14 +90,24 @@ describe('postcss-flexible', function() {
     var srcText = fs.readFileSync(srcPath, {
       encoding: 'utf8'
     })
-    const fontGear = [-1, 0, 1, 2, 3, 4]
-    const addFontSizeToSelector = function (originFontSize, gear, baseDpr) {
+    var fontGear = [-1, 0, 1, 2, 3, 4]
+    var addFontSizeToSelector = function (originFontSize, gear, baseDpr) {
       if (!baseDpr) {
         baseDpr = 2
       }
       return +originFontSize + gear*baseDpr*2
     }
-    const output = postcss().use(flexible({ enableFontSetting: true, fontGear: fontGear, addFontSizeToSelector: addFontSizeToSelector })).process(srcText).css
+    var outputCSSFile = function(gear, clonedRoot) {
+      gear !== undefined && fs.writeFileSync(path.join(__dirname, 'fontGear/fontGear_' + gear +'.css'), clonedRoot, {
+        encoding: 'utf8'
+      })
+    }
+    var output = postcss().use(flexible({
+      enableFontSetting: true,
+      fontGear: fontGear,
+      addFontSizeToSelector: addFontSizeToSelector,
+      outputCSSFile: outputCSSFile
+    })).process(srcText).css
     var expectedText = fs.readFileSync(path.join(__dirname, 'output.css'), {
       encoding: 'utf8'
     })
@@ -109,7 +127,7 @@ describe('postcss-flexible', function() {
     var srcText = fs.readFileSync(srcPath, {
       encoding: 'utf8'
     })
-    const fontGear = [-1, 0, 1, 2, 3, 4]
+    var fontGear = [-1, 0, 1, 2, 3, 4]
     var outputCSSFile = function(gear, clonedRoot) {
       gear !== undefined && fs.writeFileSync(path.join(__dirname, 'customFile/fontGear_' + gear +'.css'), clonedRoot, {
         encoding: 'utf8'

--- a/test/fontGear/fontGear_-1.css
+++ b/test/fontGear/fontGear_-1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 14px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 28px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 42px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 8px
+}
+[data-dpr="2"] .selector3 {
+    padding: 16px
+}
+[data-dpr="3"] .selector3 {
+    padding: 24px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 8px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 16px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 24px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 8px
+    }
+    [data-dpr="2"] body {
+        margin: 16px
+    }
+    [data-dpr="3"] body {
+        margin: 24px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 2px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 4px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 6px
+}

--- a/test/fontGear/fontGear_0.css
+++ b/test/fontGear/fontGear_0.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 16px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 32px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 48px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 10px
+}
+[data-dpr="2"] .selector3 {
+    padding: 20px
+}
+[data-dpr="3"] .selector3 {
+    padding: 30px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 10px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 20px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 30px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 10px
+    }
+    [data-dpr="2"] body {
+        margin: 20px
+    }
+    [data-dpr="3"] body {
+        margin: 30px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 4px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 12px
+}

--- a/test/fontGear/fontGear_1.css
+++ b/test/fontGear/fontGear_1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 18px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 36px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 54px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 12px
+}
+[data-dpr="2"] .selector3 {
+    padding: 24px
+}
+[data-dpr="3"] .selector3 {
+    padding: 36px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 12px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 24px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 36px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 12px
+    }
+    [data-dpr="2"] body {
+        margin: 24px
+    }
+    [data-dpr="3"] body {
+        margin: 36px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 6px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 12px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 18px
+}

--- a/test/fontGear/fontGear_2.css
+++ b/test/fontGear/fontGear_2.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 20px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 40px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 60px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 14px
+}
+[data-dpr="2"] .selector3 {
+    padding: 28px
+}
+[data-dpr="3"] .selector3 {
+    padding: 42px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 14px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 28px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 42px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 14px
+    }
+    [data-dpr="2"] body {
+        margin: 28px
+    }
+    [data-dpr="3"] body {
+        margin: 42px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 16px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 24px
+}

--- a/test/fontGear/fontGear_3.css
+++ b/test/fontGear/fontGear_3.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 22px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 44px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 66px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 16px
+}
+[data-dpr="2"] .selector3 {
+    padding: 32px
+}
+[data-dpr="3"] .selector3 {
+    padding: 48px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 16px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 32px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 48px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 16px
+    }
+    [data-dpr="2"] body {
+        margin: 32px
+    }
+    [data-dpr="3"] body {
+        margin: 48px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 10px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 20px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 30px
+}

--- a/test/fontGear/fontGear_4.css
+++ b/test/fontGear/fontGear_4.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 24px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 48px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 72px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 18px
+}
+[data-dpr="2"] .selector3 {
+    padding: 36px
+}
+[data-dpr="3"] .selector3 {
+    padding: 54px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 18px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 36px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 54px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 18px
+    }
+    [data-dpr="2"] body {
+        margin: 36px
+    }
+    [data-dpr="3"] body {
+        margin: 54px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 12px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 24px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 36px
+}

--- a/test/fontGearCustom/fontGear_-1.css
+++ b/test/fontGearCustom/fontGear_-1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 14px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 28px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 42px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 8px
+}
+[data-dpr="2"] .selector3 {
+    padding: 16px
+}
+[data-dpr="3"] .selector3 {
+    padding: 24px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 8px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 16px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 24px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 8px
+    }
+    [data-dpr="2"] body {
+        margin: 16px
+    }
+    [data-dpr="3"] body {
+        margin: 24px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 2px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 4px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 6px
+}

--- a/test/fontGearCustom/fontGear_0.css
+++ b/test/fontGearCustom/fontGear_0.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 16px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 32px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 48px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 10px
+}
+[data-dpr="2"] .selector3 {
+    padding: 20px
+}
+[data-dpr="3"] .selector3 {
+    padding: 30px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 10px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 20px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 30px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 10px
+    }
+    [data-dpr="2"] body {
+        margin: 20px
+    }
+    [data-dpr="3"] body {
+        margin: 30px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 4px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 12px
+}

--- a/test/fontGearCustom/fontGear_1.css
+++ b/test/fontGearCustom/fontGear_1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 18px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 36px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 54px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 12px
+}
+[data-dpr="2"] .selector3 {
+    padding: 24px
+}
+[data-dpr="3"] .selector3 {
+    padding: 36px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 12px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 24px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 36px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 12px
+    }
+    [data-dpr="2"] body {
+        margin: 24px
+    }
+    [data-dpr="3"] body {
+        margin: 36px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 6px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 12px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 18px
+}

--- a/test/fontGearCustom/fontGear_2.css
+++ b/test/fontGearCustom/fontGear_2.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 20px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 40px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 60px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 14px
+}
+[data-dpr="2"] .selector3 {
+    padding: 28px
+}
+[data-dpr="3"] .selector3 {
+    padding: 42px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 14px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 28px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 42px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 14px
+    }
+    [data-dpr="2"] body {
+        margin: 28px
+    }
+    [data-dpr="3"] body {
+        margin: 42px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 16px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 24px
+}

--- a/test/fontGearCustom/fontGear_3.css
+++ b/test/fontGearCustom/fontGear_3.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 22px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 44px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 66px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 16px
+}
+[data-dpr="2"] .selector3 {
+    padding: 32px
+}
+[data-dpr="3"] .selector3 {
+    padding: 48px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 16px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 32px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 48px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 16px
+    }
+    [data-dpr="2"] body {
+        margin: 32px
+    }
+    [data-dpr="3"] body {
+        margin: 48px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 10px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 20px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 30px
+}

--- a/test/fontGearCustom/fontGear_4.css
+++ b/test/fontGearCustom/fontGear_4.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 24px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 48px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 72px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 18px
+}
+[data-dpr="2"] .selector3 {
+    padding: 36px
+}
+[data-dpr="3"] .selector3 {
+    padding: 54px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 18px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 36px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 54px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 18px
+    }
+    [data-dpr="2"] body {
+        margin: 36px
+    }
+    [data-dpr="3"] body {
+        margin: 54px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 12px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 24px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 36px
+}

--- a/test/fontGearSource/fontGear_-1.css
+++ b/test/fontGearSource/fontGear_-1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 15px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 30px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 45px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 9px
+}
+[data-dpr="2"] .selector3 {
+    padding: 18px
+}
+[data-dpr="3"] .selector3 {
+    padding: 27px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 9px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 18px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 27px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 9px
+    }
+    [data-dpr="2"] body {
+        margin: 18px
+    }
+    [data-dpr="3"] body {
+        margin: 27px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 3px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 6px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 9px
+}

--- a/test/fontGearSource/fontGear_0.css
+++ b/test/fontGearSource/fontGear_0.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 16px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 32px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 48px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 10px
+}
+[data-dpr="2"] .selector3 {
+    padding: 20px
+}
+[data-dpr="3"] .selector3 {
+    padding: 30px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 10px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 20px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 30px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 10px
+    }
+    [data-dpr="2"] body {
+        margin: 20px
+    }
+    [data-dpr="3"] body {
+        margin: 30px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 4px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 12px
+}

--- a/test/fontGearSource/fontGear_1.css
+++ b/test/fontGearSource/fontGear_1.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 17px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 34px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 51px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 11px
+}
+[data-dpr="2"] .selector3 {
+    padding: 22px
+}
+[data-dpr="3"] .selector3 {
+    padding: 33px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 11px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 22px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 33px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 11px
+    }
+    [data-dpr="2"] body {
+        margin: 22px
+    }
+    [data-dpr="3"] body {
+        margin: 33px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 5px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 10px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 15px
+}

--- a/test/fontGearSource/fontGear_2.css
+++ b/test/fontGearSource/fontGear_2.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 18px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 36px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 54px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 12px
+}
+[data-dpr="2"] .selector3 {
+    padding: 24px
+}
+[data-dpr="3"] .selector3 {
+    padding: 36px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 12px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 24px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 36px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 12px
+    }
+    [data-dpr="2"] body {
+        margin: 24px
+    }
+    [data-dpr="3"] body {
+        margin: 36px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 6px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 12px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 18px
+}

--- a/test/fontGearSource/fontGear_3.css
+++ b/test/fontGearSource/fontGear_3.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 19px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 38px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 57px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 13px
+}
+[data-dpr="2"] .selector3 {
+    padding: 26px
+}
+[data-dpr="3"] .selector3 {
+    padding: 39px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 13px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 26px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 39px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 13px
+    }
+    [data-dpr="2"] body {
+        margin: 26px
+    }
+    [data-dpr="3"] body {
+        margin: 39px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 7px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 14px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 21px
+}

--- a/test/fontGearSource/fontGear_4.css
+++ b/test/fontGearSource/fontGear_4.css
@@ -1,0 +1,63 @@
+.selector,
+.selector2 {
+    width: 1rem;
+    line-height: 3
+}
+[data-dpr="1"] .selector, [data-dpr="1"] .selector2 {
+    font-size: 20px;
+    background-image: url(/images/qr@1x.png)
+}
+[data-dpr="2"] .selector, [data-dpr="2"] .selector2 {
+    font-size: 40px;
+    background-image: url(/images/qr@2x.png)
+}
+[data-dpr="3"] .selector, [data-dpr="3"] .selector2 {
+    font-size: 60px;
+    background-image: url(/images/qr@3x.png)
+}
+[data-dpr="1"] .selector3 {
+    padding: 14px
+}
+[data-dpr="2"] .selector3 {
+    padding: 28px
+}
+[data-dpr="3"] .selector3 {
+    padding: 42px
+}
+[data-dpr="1"] .selector4 {
+    background: url(/images/qr@1x.png) 14px 0.266667rem
+}
+[data-dpr="2"] .selector4 {
+    background: url(/images/qr@2x.png) 28px 0.266667rem
+}
+[data-dpr="3"] .selector4 {
+    background: url(/images/qr@3x.png) 42px 0.266667rem
+}
+@media screen and (min-width: 480px) {
+    [data-dpr="1"] body {
+        margin: 14px
+    }
+    [data-dpr="2"] body {
+        margin: 28px
+    }
+    [data-dpr="3"] body {
+        margin: 42px
+    }
+}
+@keyframes c-spinner-snake {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(1turn)
+    }
+}
+html[data-dpr="1"][dir="rtl"] body {
+    padding: 8px
+}
+html[data-dpr="2"][dir="rtl"] body {
+    padding: 16px
+}
+html[data-dpr="3"][dir="rtl"] body {
+    padding: 24px
+}


### PR DESCRIPTION
add: generate different css files with fontGear

more custom settings:
- `fontGear`: array, default `[-1, 0, 1, 2, 3, 4]`, the gears of font you want to use
- `enableFontSetting`: boolean, default `false`, whether to enable the fontSetting
- `addFontSizeToSelector`: `function`, determines the logic when func adds fontSize to each declaration
- `outputCSSFile`: `function`, determins how the plugin outputs the css file